### PR TITLE
do not export lttng_last_tsc.

### DIFF
--- a/wrapper/trace-clock.c
+++ b/wrapper/trace-clock.c
@@ -25,5 +25,4 @@
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0))
 DEFINE_PER_CPU(local_t, lttng_last_tsc);
-EXPORT_PER_CPU_SYMBOL(lttng_last_tsc);
 #endif /* #else #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,16,0)) */


### PR DESCRIPTION
this symbol collides with lttng-modules.

Signed-off-by: Francois Doray francois.pierre-doray@polymtl.ca
